### PR TITLE
Remove unused variables and fix log

### DIFF
--- a/modules/mod_audio_fork/lws_glue.cpp
+++ b/modules/mod_audio_fork/lws_glue.cpp
@@ -295,9 +295,8 @@ namespace {
 
 extern "C" {
   int parse_ws_uri(switch_channel_t *channel, const char* szServerUri, char* host, char *path, unsigned int* pPort, int* pSslFlags) {
-    int i = 0, offset;
+    int offset;
     char server[MAX_WS_URL_LEN + MAX_PATH_LEN];
-    char *saveptr;
     int flags = LCCSCF_USE_SSL;
     
     if (switch_true(switch_channel_get_variable(channel, "MOD_AUDIO_FORK_ALLOW_SELFSIGNED"))) {
@@ -336,7 +335,7 @@ extern "C" {
       *pPort = 80;
     }
     else {
-      switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE, "parse_ws_uri - error parsing uri %s: invalid scheme\n", szServerUri);;
+      switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE, "parse_ws_uri - error parsing uri %s: invalid scheme\n", szServerUri);
       return 0;
     }
 

--- a/modules/mod_jambonz_transcribe/jb_transcribe_glue.cpp
+++ b/modules/mod_jambonz_transcribe/jb_transcribe_glue.cpp
@@ -32,9 +32,8 @@ namespace {
   static uint32_t playCount = 0;
 
   static int parse_ws_uri(switch_channel_t *channel, const char* szServerUri, char* host, char *path, unsigned int* pPort, int* pSslFlags) {
-    int i = 0, offset;
+    int offset;
     char server[MAX_WS_URL_LEN + MAX_PATH_LEN];
-    char *saveptr;
     int flags = LCCSCF_USE_SSL;
     
     if (switch_true(switch_channel_get_variable(channel, "MOD_AUDIO_FORK_ALLOW_SELFSIGNED"))) {
@@ -73,7 +72,7 @@ namespace {
       *pPort = 80;
     }
     else {
-      switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE, "parse_ws_uri - error parsing uri %s: invalid scheme\n", szServerUri);;
+      switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE, "parse_ws_uri - error parsing uri %s: invalid scheme\n", szServerUri);
       return 0;
     }
 


### PR DESCRIPTION
## Summary
- clean up unused vars in `lws_glue.cpp` and `jb_transcribe_glue.cpp`
- remove stray semicolons in error log

## Testing
- `make -C modules/mod_audio_fork` *(fails: No makefile found)*
- `make -C modules/mod_jambonz_transcribe` *(fails: No makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_686250e8ebf8832bbcf4aafc08977543