### PR TITLE
Remove self-referencing mod_google_tts symlink

### DIFF
--- a/modules/mod_google_tts/mod_google_tts
+++ b/modules/mod_google_tts/mod_google_tts
@@ -1,1 +1,0 @@
-mod_google_tts


### PR DESCRIPTION
## Summary
- delete the `modules/mod_google_tts/mod_google_tts` symlink

## Testing
- `find modules -type l -ls`

------
https://chatgpt.com/codex/tasks/task_e_68624cffe324832ba99ee237f1929b81