### PR TITLE
Fix datalen check in google_tts and remove bad symlink

### DIFF
--- a/modules/mod_google_tts/mod_google_tts
+++ b/modules/mod_google_tts/mod_google_tts
@@ -1,1 +1,0 @@
-mod_google_tts

--- a/modules/mod_google_tts/mod_google_tts.c
+++ b/modules/mod_google_tts/mod_google_tts.c
@@ -103,8 +103,8 @@ static switch_status_t speech_read_tts(switch_speech_handle_t *sh, void *data, s
 		unlink(google->file);
 		return SWITCH_STATUS_FALSE;
 	}
-	*datalen = my_datalen * 2;
-	if (datalen == 0) {
+        *datalen = my_datalen * 2;
+        if (*datalen == 0) {
 		switch_core_file_close(google->fh);
 		unlink(google->file);
 		return SWITCH_STATUS_BREAK;


### PR DESCRIPTION
## Summary
- fix incorrect pointer comparison in `speech_read_tts`
- remove self-referencing symlink from mod_google_tts

## Testing
- `npm test` (fails: no test specified)
- `npm test` from repo root (fails to find package.json)


------
https://chatgpt.com/codex/tasks/task_e_686249f03f34832b8d0949451ef06b34